### PR TITLE
Feat/add perform python linting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+max-line-length = 120
+exclude = venv, .tox, *.egg, *_pb2.py, build, temp,
+select = E, W, F
+doctests = true
+ignore = E731, W503, E203, E231, E241, E221, E225, E226, E271, E275

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,66 @@
+# Apply to all files without committing:
+#   pre-commit run --all-files
+# Apply to changed files:
+#   pre-commit run
+# Update this file:
+#   pre-commit autoupdate
+# Run a specific hook:
+#   pre-commit run <hook id>
+
+ci:
+  autofix_prs: true
+  autoupdate_commit_msg: "[pre-commit.ci] pre-commit suggestions"
+  autoupdate_schedule: weekly
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-ast
+        files: \.py$  # Restrict to .py files only
+      - id: check-byte-order-marker
+        files: \.py$  # Restrict to .py files only
+      - id: check-case-conflict
+        files: \.py$  # Restrict to .py files only
+      - id: check-toml
+      - id: check-yaml
+      - id: debug-statements
+        files: \.py$  # Restrict to .py files only
+      - id: detect-private-key
+      - id: end-of-file-fixer
+        files: \.py$  # Restrict to .py files only
+      - id: trailing-whitespace
+        files: \.py$  # Restrict to .py files only
+      - id: mixed-line-ending
+        files: \.py$  # Restrict to .py files only
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.19.1
+    hooks:
+      - id: pyupgrade
+        args: [--py36-plus]
+        files: \.py$  # Restrict to .py files only
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.10.1
+    hooks:
+      - id: isort
+        files: \.py$  # Restrict to .py files only
+        name: Format imports
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.2.0
+    hooks:
+      - id: flake8
+        files: \.py$  # Restrict to .py files only
+        args: ['--config', '.flake8'] 
+  # black for automatic code formatting
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+        files: \.py$
+        language_version: python3
+        name: Format code
+  - repo: https://github.com/yoheimuta/protolint
+    rev: v0.53.0
+    hooks:
+      - id: protolint
+        files: \.proto$  # Leave protolint for .proto files only

--- a/.protolint.yaml
+++ b/.protolint.yaml
@@ -1,0 +1,51 @@
+
+# Adapted from
+# https://github.com/yoheimuta/protolint/blob/master/_example/config/.protolint.yaml
+---
+# Lint directives.
+lint:
+  # Linter files to walk.
+  files:
+    # The specific files to exclude.
+    exclude:
+      # NOTE: UNIX paths will be properly accepted by both UNIX and Windows.
+      - ../proto/invalidFileName.proto
+
+  # Linter rules.
+  # Run `protolint list` to see all available rules.
+  rules:
+  
+    # The specific linters to add.
+    add:
+      - FIELD_NAMES_LOWER_SNAKE_CASE
+      - MESSAGE_NAMES_UPPER_CAMEL_CASE
+      - MAX_LINE_LENGTH
+      - INDENT
+      - FIELD_NAMES_EXCLUDE_PREPOSITIONS
+      - FILE_NAMES_LOWER_SNAKE_CASE
+      - IMPORTS_SORTED
+      - PACKAGE_NAME_LOWER_CASE
+      - ORDER
+      - PROTO3_FIELDS_AVOID_REQUIRED
+      - PROTO3_GROUPS_AVOID
+      - REPEATED_FIELD_NAMES_PLURALIZED
+      - QUOTE_CONSISTENT
+
+  # Linter rules option.
+  rules_option:
+    # MAX_LINE_LENGTH rule option.
+    max_line_length:
+      # Enforces a maximum line length
+      max_chars: 120
+      # Specifies the character count for tab characters
+      tab_chars: 2
+
+    # FILE_NAMES_LOWER_SNAKE_CASE rule option.
+    file_names_lower_snake_case:
+      excludes:
+        - ../proto/invalidFileName.proto
+
+    # QUOTE_CONSISTENT rule option.
+    quote_consistent:
+      # Available quote are "double" or "single".
+      quote: double

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+
+# Run pre-commit hooks on all files
+lint:
+	@echo "Running pre-commit linting on all files..."
+	pre-commit run --all-files
+
+# Run pre-commit hooks on changed files
+lint-changed-files:
+	@echo "Running pre-commit lint on changed files..."
+	pre-commit run
+
+# Update pre-commit hooks to the latest versions
+autoupdate:
+	@echo "Updating pre-commit hooks..."
+	pre-commit autoupdate
+
+# Run a specific hook (e.g., flake8, black, isort, etc.)
+run-lint-hook:
+	@echo "Running specific hook: $(hook)"
+	pre-commit run $(hook)
+
+.PHONY: lint lint-changed-files autoupdate run-lint-hook

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,4 +7,3 @@ order_by_type = false
 [tool.black]
 line-length = 120
 exclude = '''/venv|\.tox|\.egg|build'''
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.isort]
+profile = "black"
+line_length = 120
+force_sort_within_sections = false
+order_by_type = false
+
+[tool.black]
+line-length = 120
+exclude = '''/venv|\.tox|\.egg|build'''
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,3 +70,7 @@ datasets
 # pin required for torch 2.1.0
 urllib3<2
 ludwig==0.10.2 # Must downgrade to 0.10.2 or it won't be able to load in dockerized environment using Ludwig's official image
+black==25.1.0
+flake8==7.2.0
+isort==6.0.1
+pre-commit==4.2.0


### PR DESCRIPTION
## 🔧 Pre-commit Hook & Linting Automation Setup

The following PR sets up **automated code formatting and linting** for Python and YAML files using [`pre-commit`](https://pre-commit.com/). It includes configuration and tools to ensure consistent code style and quality across the codebase.

### ✅ Key Features

- **Pre-commit hooks** to automatically run formatters and linters before every commit.
- **Auto-fixing** support via `black` and `isort`.
- **Makefile commands** for convenient manual linting when needed.

---

### 🗂️ Files & Configuration

- **`.pre-commit-config.yaml`**  
  Defines the list of hooks to run on staged files:
  - 🧹 Common checks (`check-yaml`, `end-of-file-fixer`, etc.)
  - 🐍 Python formatters/linters:
    - `black`
    - `flake8`
    - `isort`
    - `pyupgrade`
  - 📦 Also includes `protolint` for `.proto` files.

- **`pyproject.toml`**  
  Central configuration for:
  - `flake8`: linting rules, ignore list, max line length
  - `black`: line length and exclusions
  - `isort`: aligned with black’s style

- **`Makefile`**  
  Contains simple CLI commands to trigger pre-commit operations:
  ```makefile
  make lint                   # Run all pre-commit hooks on all files
  make lint-changed-files     # Run hooks only on changed files
  make autoupdate             # Update pre-commit repo revisions
  make run-lint-hook hook=black  # Run a specific hook manually (black in this example)
