### PR TITLE
fix: disable usage of symbolic links for local directories

### DIFF
--- a/multi_serve.py
+++ b/multi_serve.py
@@ -115,7 +115,8 @@ def download_model_from_huggingface(
                 repo_id=repo_id,
                 force_download=force_download,
                 local_dir=repo_dir,
-                repo_type="model"
+                repo_type="model",
+                local_dir_use_symlinks=False
             )
         except Exception as e:
             logging.warning(f"Failed to download the model from hugging_face: {e}")


### PR DESCRIPTION
The following PR updates the Hugging Face `snapshot_download()` call to explicitly use: `local_dir_use_symlinks=False`. 

By default, snapshot_download() creates symlinks in the specified local_dir that point to files in the Hugging Face cache (typically  `root/.cache/huggingface/hub`). While efficient for disk usage, this behavior has limitations in certain environments:

- Symbolic links can break if the cache is not present or is cleared.
- When packaging the model directory (e.g., into a Docker container), symlinks may point to invalid locations.
- Our current setup does not mount the Hugging Face cache as a Docker volume, to avoid unnecessary storage usage and persistence across runs.



